### PR TITLE
Fix not targeting the correct container when multiple userPreferencesPages are in the document

### DIFF
--- a/src/Jellyfin.Plugin.PluginPages/Controller/userpluginsettings.html
+++ b/src/Jellyfin.Plugin.PluginPages/Controller/userpluginsettings.html
@@ -3,7 +3,7 @@
     </div>
     <script>
         setTimeout(function(){
-            let container = document.getElementsByClassName('userPluginSettingsContainer')[0];
+            let container = document.querySelector('.userPreferencesPage:not(.hide) .userPluginSettingsContainer');
 
             let url = new URL(window.location.protocol + "//" + window.location.host + window.location.hash.substring(1));
             let pageUrl = url.searchParams.get('pageUrl');


### PR DESCRIPTION
This is just a very small fix that will target the correct container to display the page contents when multiple userPreferencesPages are in the document. Currently if there are multiple present it will overwrite the contents of the first one, even if it is hidden and is showing the second.